### PR TITLE
add -m flag, ignore minor errors

### DIFF
--- a/bin/camex.sh
+++ b/bin/camex.sh
@@ -4,4 +4,4 @@ PREFIX="$1"
 if [ -f "$1" ]; then
     PREFIX="selection"
 fi
-/usr/local/bin/exiftool -r -api largefilesupport=1 -echo 'File Name,Clip Directory,Camera Aperture,Camera Aperture Type,Camera Format,Camera FPS,Camera Manufacturer,Camera Serial #,Camera Type,Codec Bitrate,Gamma Notes,ISO,Lens Type,Shutter,White Balance Tint,Comments' -p '${FileName},${Directory},${Aperture},${PictureMode},${Format},${VideoFrameRate},${Make},${InternalSerialNumber},${Model},${AvgBitrate},${FilmMode},${ISO},${LensInfo},${ShutterSpeed},${WhiteBalance},${VideoRecordingMode}' "$@" > $PREFIX-camera-metadata.csv
+/usr/local/bin/exiftool -m -r -api largefilesupport=1 -echo 'File Name,Clip Directory,Camera Aperture,Camera Aperture Type,Camera Format,Camera FPS,Camera Manufacturer,Camera Serial #,Camera Type,Codec Bitrate,Gamma Notes,ISO,Lens Type,Shutter,White Balance Tint,Comments' -p '${FileName},${Directory},${Aperture},${PictureMode},${Format},${VideoFrameRate},${Make},${InternalSerialNumber},${Model},${AvgBitrate},${FilmMode},${ISO},${LensInfo},${ShutterSpeed},${WhiteBalance},${VideoRecordingMode}' "$@" > $PREFIX-camera-metadata.csv


### PR DESCRIPTION
Use the -m flag to ignore minor errors and output blank fields instead of outputting nothing at all